### PR TITLE
Remove deprecated treeview parameter in CellRendererIcon

### DIFF
--- a/playlist.py
+++ b/playlist.py
@@ -57,7 +57,7 @@ class PlayList(Gtk.ScrolledWindow):
         self.selection = self.listview.get_selection()
         self.selection.set_mode(Gtk.SelectionMode.SINGLE)
 
-        renderer_icon = CellRendererIcon(self.listview)
+        renderer_icon = CellRendererIcon()
         renderer_icon.props.icon_name = 'emblem-notification'
         renderer_icon.props.width = 20
         renderer_icon.props.height = 20


### PR DESCRIPTION
Fixes #14 

**Tested on:** Sugar 0.112, Ubuntu 16.04