### PR TITLE
Add support for audio visualization

### DIFF
--- a/activity.py
+++ b/activity.py
@@ -429,19 +429,7 @@ class JukeboxActivity(activity.Activity):
         self.remove_alert(alert)
 
     def __player_play_cb(self, widget):
-        # Do not show the visualization widget if we are playing just
-        # an audio stream
-
-        def callback():
-            if self.player.playing_video():
-                self._switch_canvas(True)
-            else:
-                self._switch_canvas(True)
-            return False
-
-        # HACK: we need a timeout here because gstreamer returns
-        # n-video = 0 if we call it immediately
-        GObject.timeout_add(1000, callback)
+        self._switch_canvas(True)
 
     def __player_error_cb(self, widget, message, detail):
         self.player.stop()

--- a/activity.py
+++ b/activity.py
@@ -436,7 +436,7 @@ class JukeboxActivity(activity.Activity):
             if self.player.playing_video():
                 self._switch_canvas(True)
             else:
-                self._switch_canvas(False)
+                self._switch_canvas(True)
             return False
 
         # HACK: we need a timeout here because gstreamer returns

--- a/player.py
+++ b/player.py
@@ -58,7 +58,7 @@ class GstPlayer(GObject.GObject):
         # Create GStreamer elements
         self.player = Gst.ElementFactory.make('playbin', None)
         # FIXME: visualisation is in separate window
-        # self.player.props.flags |= 8
+        self.player.props.flags |= 8
         self.pipeline.add(self.player)
 
     def init_view_area(self, videowidget):


### PR DESCRIPTION
I don't see any errors or overlapping windows in the jukebox audio visualization, so here's a working proof:

## Screenshots
![jukebox-s](https://user-images.githubusercontent.com/48695438/72099714-3f346080-3332-11ea-8dc4-f2c0f82ea219.gif)

Seems like this bug only existed on previous gstreamer versions, but I have no exact reason for that :wink: 
## System Information
```
$ neofetch
                   -`                    ss@srevinsaju 
                  .o+`                   ------------- 
                 `ooo/                   OS: Arch Linux x86_64 
                `+oooo:                  Host: G31M-ES2C 
               `+oooooo:                 Kernel: 5.4.6-arch3-1 
               -+oooooo+:                Uptime: 8 hours, 38 mins 
             `/:-:++oooo+:               Packages: 1158 (pacman), 18 (flatpak) 
            `/++++/+++++++:              Shell: zsh 5.7.1 
           `/++++++++++++++:             Resolution: 1366x768 
          `/+++ooooooooooooo/`           DE: Plasma 
         ./ooosssso++osssssso+`          WM: KWin 
        .oossssso-````/ossssss+`         WM Theme: McMojave 
       -osssssso.      :ssssssso.        Theme: Breeze-Dark [GTK2], Mojave-dark-s 
      :osssssss/        osssso+++.       Icons: Papirus-Dark [GTK2/3] 
     /ossssssss/        +ssssooo/-       Terminal: yakuake 
   `/ossssso+/:-        -:/+osssso+-     Terminal Font: Ubuntu Mono 11 
  `+sso+:-`                 `.-/+oso:    CPU: Intel Core 2 4300 (2) @ 1.800GHz 
 `++:.                           `-/+/   GPU: NVIDIA GeForce GT 610 
 .`                                 `/   Memory: 2030MiB / 2993MiB 

                                                                 
                                                                 

```

## GI version
### GTK version
```
Repository      : extra
Name            : gtk3
Version         : 1:3.24.13-1
Description     : GObject-based multi-platform GUI toolkit
Architecture    : x86_64
URL             : https://www.gtk.org/
Licenses        : LGPL
Groups          : None
Provides        : gtk3-print-backends
Depends On      : atk  cairo  libxcursor  libxinerama  libxrandr  libxi  libepoxy
                  gdk-pixbuf2  dconf  libxcomposite  libxdamage  pango
                  shared-mime-info  at-spi2-atk  wayland  libxkbcommon
                  adwaita-icon-theme  json-glib  librsvg  wayland-protocols
                  desktop-file-utils  mesa  cantarell-fonts  colord  rest
                  libcups  libcanberra  fribidi  iso-codes  gtk-update-icon-cache
Optional Deps   : None
Conflicts With  : gtk3-print-backends
Replaces        : gtk3-print-backends<=3.22.26-1
Download Size   : 10.71 MiB
Installed Size  : 73.34 MiB
Packager        : Jan Alexander Steffens (heftig) <jan.steffens@gmail.com>
Build Date      : Wed 27 Nov 2019 11:05:34 PM +03
Validated By    : MD5 Sum  SHA-256 Sum  Signature
```

### GSteamer Version
```
Repository      : extra
Name            : gstreamer
Version         : 1.16.2-1
Description     : GStreamer open-source multimedia framework core library
Architecture    : x86_64
URL             : https://gstreamer.freedesktop.org/
Licenses        : LGPL
Groups          : None
Provides        : None
Depends On      : libxml2  glib2  libunwind  libcap  libelf
Optional Deps   : None
Conflicts With  : None
Replaces        : None
Download Size   : 1946.00 KiB
Installed Size  : 18750.32 KiB
Packager        : Jan Alexander Steffens (heftig) <jan.steffens@gmail.com>
Build Date      : Fri 06 Dec 2019 10:57:41 PM +03
Validated By    : MD5 Sum  SHA-256 Sum  Signature
```

Please review @quozl @walterbender @pro-panda @Aniket21mathur 