### PR TITLE
Fix playlist navigation

### DIFF
--- a/playlist.py
+++ b/playlist.py
@@ -93,12 +93,19 @@ class PlayList(Gtk.ScrolledWindow):
 
     def move_up(self):
         selected_iter = self.selection.get_selected()[1]
-        position = self.treemodel.get_iter(
-            int(str(self.treemodel.get_path(selected_iter))) - 1)
+        if selected_iter is None:
+            return
+
+        position = self.treemodel.iter_previous(
+            self.treemodel.get_iter(self.treemodel.get_path(selected_iter)))
+        if position is None:
+            return
+
         self.treemodel.move_before(selected_iter, position)
         i = self._current_playing
         self._items[i - 1], self._items[i] = \
             self._items[i], self._items[i - 1]
+
         index = 0
         for tree_item, playlist_item in zip(self.treemodel, self._items):
             tree_item[0] = index
@@ -108,8 +115,14 @@ class PlayList(Gtk.ScrolledWindow):
 
     def move_down(self):
         selected_iter = self.selection.get_selected()[1]
-        position = self.treemodel.get_iter(
-            int(str(self.treemodel.get_path(selected_iter))) + 1)
+        if selected_iter is None:
+            return
+
+        position = self.treemodel.iter_next(
+            self.treemodel.get_iter(self.treemodel.get_path(selected_iter)))
+        if position is None:
+            return
+
         self.treemodel.move_after(selected_iter, position)
         i = self._current_playing
         self._items[i + 1], self._items[i] = \


### PR DESCRIPTION
Clicking the move-up and move-down buttons when there were no songs in 
the playlist above or below the selected song, threw errors.
This fix moves the song only if another song exists at the position it is
to be moved into.
 
Traceback:
Clicking MOVE UP when there's no song above:
```
Traceback (most recent call last):
  File "/usr/share/sugar/activities/Jukebox.activity/activity.py", line 201, in _move_down_cb
    self.playlist_widget.move_down()
  File "/usr/share/sugar/activities/Jukebox.activity/playlist.py", line 111, in move_down
    position = self.treemodel.get_iter(
  File "/usr/lib/python3/dist-packages/gi/overrides/Gtk.py", line 869, in get_iter
    raise ValueError("invalid tree path '%s'" % path)
ValueError: invalid tree path '1'

```
Clicking MOVE DOWN when there's no song below:
```
(sugar-activity3:1768): Gtk-WARNING **: 15:55:15.881: ../../../../gtk/gtktreemodel.c:646:
Negative numbers in path -1 passed to gtk_tree_path_new_from_string
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/gi/overrides/Gtk.py", line 1206, in __new__
    return TreePath.new_from_string(path)
TypeError: constructor returned NULL

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/share/sugar/activities/Jukebox.activity/activity.py", line 198, in _move_up_cb
    self.playlist_widget.move_up()
  File "/usr/share/sugar/activities/Jukebox.activity/playlist.py", line 96, in move_up
    position = self.treemodel.get_iter(
  File "/usr/lib/python3/dist-packages/gi/overrides/Gtk.py", line 866, in get_iter
    path = self._coerce_path(path)
  File "/usr/lib/python3/dist-packages/gi/overrides/Gtk.py", line 841, in _coerce_path
    return TreePath(path)
  File "/usr/lib/python3/dist-packages/gi/overrides/Gtk.py", line 1208, in __new__
    raise TypeError("could not parse subscript '%s' as a tree path" % path)
TypeError: could not parse subscript '-1' as a tree path
```

Fixes #30