### PR TITLE
Prevent Gtk-CRITICAL warning when removing _stop and _separator from toolbar

### DIFF
--- a/activity.py
+++ b/activity.py
@@ -202,8 +202,10 @@ class JukeboxActivity(activity.Activity):
 
     def _configure_cb(self, event=None):
         toolbar = self.get_toolbar_box().toolbar
-        toolbar.remove(self._stop)
-        toolbar.remove(self._separator)
+        if self._stop.get_parent() == toolbar:
+            toolbar.remove(self._stop)
+        if self._separator.get_parent() == toolbar:
+            toolbar.remove(self._separator)
         if Gdk.Screen.width() < Gdk.Screen.height():
             self._control_toolbar_button.show()
             self._control_toolbar_button.set_expanded(True)


### PR DESCRIPTION
Issue:
When the window gets resized the following warning occurs, Gtk-CRITICAL **: 03:45:45.314: gtk_toolbar_remove: assertion 'content_to_remove != NULL' failed

Change:
Added a safety check to ensure that a toolbar item has toolbar as a parent before attempting to remove it. This resolves a Gtk-CRITICAL warning that occurred when trying to remove an item that was not in the toolbar.

Fixes #32
@chimosky @sourabhaa